### PR TITLE
redeclare custom route for devise sessions controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   resources :stores, only: [:show, :edit, :update] do
     resources :products
   end
-  devise_for :users
+  devise_for :users, controllers: { sessions: 'users/sessions' }
 
   resources :users, only: [:create]
   get ':username' =>  'users#show'


### PR DESCRIPTION
This is necessary to add cookie actions when users log in / logout, which is _required_ for proper chat functionality